### PR TITLE
change skin tone settings from input to select

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ from ulauncher.api.shared.action.DoNothingAction import DoNothingAction
 
 logger = logging.getLogger(__name__)
 extension_icon = 'images/icon.png'
-allowed_skin_tones = ["", "dark", "light", "medium", "medium-dark", "medium-light"]
 db_path = os.path.join(os.path.dirname(__file__), 'emoji.sqlite')
 conn = sqlite3.connect(db_path, check_same_thread=False)
 conn.row_factory = sqlite3.Row
@@ -23,6 +22,7 @@ class EmojiExtension(Extension):
     def __init__(self):
         super(EmojiExtension, self).__init__()
         self.subscribe(KeywordQueryEvent, KeywordQueryEventListener())
+        self.allowed_skin_tones = ["", "dark", "light", "medium", "medium-dark", "medium-light"]
 
 
 class KeywordQueryEventListener(EventListener):
@@ -45,7 +45,7 @@ class KeywordQueryEventListener(EventListener):
             ])
 
         skin_tone = extension.preferences['skin_tone']
-        if skin_tone not in allowed_skin_tones:
+        if skin_tone not in extension.allowed_skin_tones:
             logger.warning('Unknown skin tone "%s"' % skin_tone)
             skin_tone = ''
 

--- a/manifest.json
+++ b/manifest.json
@@ -14,10 +14,18 @@
         },
         {
             "id": "skin_tone",
-            "type": "input",
+            "type": "select",
             "name": "Skin Tone",
-            "description": "Allowed values: dark, light, medium, medium-dark, medium-light, or empty",
-            "default_value": ""
+            "description": "Choose the skin tone for your emojis",
+            "default_value": "default",
+            "options": [
+                "default",
+                "light",
+                "medium-light",
+                "medium",
+                "medium-dark",
+                "dark"
+            ]
         }
     ]
 }


### PR DESCRIPTION
closes #1

This seemed like a good excercise to see how extensions work as well. Since I'm not a Python programmer, you might want to check the code first before pulling.

I just realize that I left the change where I moved the global variable (?) ```allowed_skin_tones```  into the extension class. Felt natural for me to have it there but then again, I don't know Python and I'm not sure if what I think I did is actually what I did :sweat_smile: 