### PR TITLE
Fixed wrong calculation of max number in "View more"

### DIFF
--- a/main.py
+++ b/main.py
@@ -203,7 +203,7 @@ def search(event, extension, search_term=None, offset=0):
                 ExtensionResultItem(
                     icon="images/more.png",
                     name="View more",
-                    description=f"You are viewing results from {offset + 1} to {offset + i}. Click for more",
+                    description=f"You are viewing results from {offset + 1} to {offset + displayed}. Click for more",
                     on_enter=ExtensionCustomAction(
                         data={"offset": i, "search_term": search_term},
                         keep_app_open=True,


### PR DESCRIPTION
the "i" variable needs to be replaced with "displayed" here.

Not good at explaining but it should make sense I hope.

Before:
<img width="589" height="615" alt="image" src="https://github.com/user-attachments/assets/6928338a-6c77-4e21-88af-bd60b22df481" />
(obviously wrong)

After:
<img width="581" height="605" alt="image" src="https://github.com/user-attachments/assets/4b200dcb-8a6e-4ba1-aca5-3da8443ebca8" />